### PR TITLE
[#9] Disable zero attack animation

### DIFF
--- a/Assets/Scripts/Game.cs
+++ b/Assets/Scripts/Game.cs
@@ -92,6 +92,8 @@ public class Game : MonoBehaviour
         int armyCount = Army.transform.childCount;
         for (int i = 0; i < armyCount; i++)
         {
+            //Проверка на нулевой урон
+            if (AttackValue <= 0) break;
             //Применение свойств до атаки
             GameObject Attacker = Army.transform.GetChild(0).gameObject;
             yield return StartCoroutine(SpawnHit(IEnemy.transform.position, Attacker.transform.position));
@@ -103,7 +105,6 @@ public class Game : MonoBehaviour
                 Attacker.transform.SetParent(discard);
             }
             //Применение свойств после атаки
-            if (AttackValue <= 0) break;      
         }
         //Примененние свойств после атаки (Общее) 
         if (AttackValue > 0) player.AttackPlayer(AttackValue);

--- a/Assets/Scripts/Game.cs
+++ b/Assets/Scripts/Game.cs
@@ -73,8 +73,12 @@ public class Game : MonoBehaviour
         {            
             //Применение свойств до атаки
             GameObject Attacker = Army.transform.GetChild(i).gameObject;
-            yield return StartCoroutine(SpawnHit(Attacker.transform.position,IEnemy.transform.position));            
-            enemy.GetHit(Attacker.GetComponent<CardInfo>().SelfCard.Damage);            
+            //Игнорирование юнитов с атакой равной нулю
+            if (Attacker.GetComponent<CardInfo>().SelfCard.Damage != 0)
+            {
+                yield return StartCoroutine(SpawnHit(Attacker.transform.position, IEnemy.transform.position));
+                enemy.GetHit(Attacker.GetComponent<CardInfo>().SelfCard.Damage);
+            }
             //Применение свойств после атаки
         }
         if (enemy.EnemyHealth == 0)


### PR DESCRIPTION
Closes #9 
Введена проверка на нулевой урон у карт. Если урон не равен 0-лю, тогда анимация проигрывается.
Перенесена проверка нулевого урона у босса, что позволяет также убрать анимацию если у босса урон равен 0 изначально.